### PR TITLE
Add symbol for easier usage in Pipelines and Job DSL

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/notifications/SkipNotificationsTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/notifications/SkipNotificationsTrait.java
@@ -31,6 +31,7 @@ import jenkins.scm.api.trait.SCMSourceContext;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import jenkins.scm.impl.trait.Discovery;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class SkipNotificationsTrait extends SCMSourceTrait {
@@ -60,6 +61,7 @@ public class SkipNotificationsTrait extends SCMSourceTrait {
      */
     @Extension
     @Discovery
+    @Symbol("skipNotifications")
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {
 
         /**


### PR DESCRIPTION
Example for Jenkinsfile

**before**
`resolveScm source: bitbucket(..., traits: [[$class: 'SkipNotificationsTrait']])`

**after**
`resolveScm source: bitbucket(..., traits: [skipNotifications()])`