### PR TITLE
Show the trait in the "-- General --" section

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/notifications/SkipNotificationsTrait.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/notifications/SkipNotificationsTrait.java
@@ -59,7 +59,6 @@ public class SkipNotificationsTrait extends SCMSourceTrait {
      * Our descriptor.
      */
     @Extension
-    @Discovery
     public static class DescriptorImpl extends SCMSourceTraitDescriptor {
 
         /**


### PR DESCRIPTION
For Bitbucket behaviors there are these sections:
* "-- Within repository --"
* "-- General --"
* "-- Git --"
* "-- Mercurial --"

Currently this trait shows up in "-- Within repository --".

It should better show up in "-- General --" because in "-- Within repository --" all the discovery/selection traits are listed but this trait is about a different aspect.