### PR TITLE
support skipping the notification in GitHub branch source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Branch Source Plugin custom trait
 
 [![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/skip-notifications-trait.svg)](https://plugins.jenkins.io/skip-notifications-trait)
+[![GitHub release](https://img.shields.io/github/tag/jenkinsci/skip-notifications-trait-plugin.svg?label=changelog)](https://github.com/jenkinsci/skip-notifications-trait-plugin/blob/master/CHANGELOG.md)
 [![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/skip-notifications-trait.svg?color=blue)](https://plugins.jenkins.io/skip-notifications-trait)
 
 This is an extension plugin which adds custom feature to the Bitbucket and GitHub Branch Source plugins, allowing to disable build status notifications.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,31 @@
 # Branch Source Plugin custom trait
 
-This repository contains a custom trait to disable build status notifications of BitBucket Branch Source Plugin
-Please check documentation for original plugin here: https://wiki.jenkins.io/display/JENKINS/Bitbucket+Branch+Source+Plugin
+[![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/skip-notifications-trait.svg)](https://plugins.jenkins.io/skip-notifications-trait)
+[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/skip-notifications-trait.svg?color=blue)](https://plugins.jenkins.io/skip-notifications-trait)
 
-It provides trait for
- - Bitbucket: Skip build notifications
+This is an extension plugin which adds custom feature to the Bitbucket and GitHub Branch Source plugins, allowing to disable build status notifications.
 
+## Usage
 
+### BitBucket
+
+```Groovy
+  checkout resolveScm(
+    source: bitbucket(
+      repoOwner: 'example-owner',
+      repository: 'example-repository',
+      traits: [
+        skipNotifications(),
+        ...,
+      ]
+    )
+  )
+```
+
+## License
+
+ [MIT License](./LICENSE.md)
+
+## More information
+
+It was initially submitted as a PR for core plugin [PR](https://github.com/jenkinsci/bitbucket-branch-source-plugin/pull/132), but owners suggested to package it as an extension.

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
         <artifactId>jsch</artifactId>
         <version>0.1.55</version>
       </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>token-macro</artifactId>
+        <version>1.12.1</version>
+      </dependency>
       <!-- Require upper bound dependencies -->
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -106,7 +111,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>github-branch-source</artifactId>
-      <version>2.5.0</version>
+      <version>2.4.0</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
   <name>Skip Notifications Trait plugin</name>
   <description>This is an extension for Bitbucket and GitHub Branch Source Plugin, which allows to skip notifying BitBucket or GitHub instances about build statuses.</description>
-  <url>https://wiki.jenkins.io/display/JENKINS/Skip+Notifications+Trait+Plugin</url>
+  <url>https://github.com/jenkinsci/skip-notifications-trait-plugin</url>
   <licenses>
     <license>
       <name>MIT License</name>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
   <packaging>hpi</packaging>
 
   <name>Skip Notifications Trait plugin</name>
-  <description>This is an extension for Bitbucket Branch Source Plugin, which allows to skip notifying BitBucket instance about build statuses.</description>
+  <description>This is an extension for Bitbucket and GitHub Branch Source Plugin, which allows to skip notifying BitBucket or GitHub instances about build statuses.</description>
   <url>https://wiki.jenkins.io/display/JENKINS/Skip+Notifications+Trait+Plugin</url>
   <licenses>
     <license>
@@ -63,7 +63,7 @@
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
     <branchsource.version>2.4.4</branchsource.version>
-    <scm-api.version>2.2.7</scm-api.version>
+    <scm-api.version>2.3.0</scm-api.version>
   </properties>
 
   <dependencyManagement>
@@ -73,18 +73,40 @@
         <artifactId>jsch</artifactId>
         <version>0.1.55</version>
       </dependency>
+      <!-- Require upper bound dependencies -->
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.7</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>git</artifactId>
+        <version>3.9.3</version>
+      </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>scm-api</artifactId>
         <version>${scm-api.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>structs</artifactId>
+        <version>1.17</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>cloudbees-bitbucket-branch-source</artifactId>
       <version>${branchsource.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>github-branch-source</artifactId>
+      <version>2.5.0</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/jenkinsci/plugins/github/notifications/SkipNotificationsTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github/notifications/SkipNotificationsTrait.java
@@ -1,0 +1,93 @@
+/*
+The MIT License
+
+Copyright (c) 2019, Elastic, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.jenkinsci.plugins.github.notifications;
+
+import org.jenkinsci.plugins.github_branch_source.GitHubSCMSource;
+import org.jenkinsci.plugins.github_branch_source.GitHubSCMSourceContext;
+import hudson.Extension;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Disables notifications.
+ *
+ * @since 1.0.4
+ */
+public class SkipNotificationsTrait extends SCMSourceTrait {
+
+    /**
+     * Constructor for stapler.
+     */
+    @DataBoundConstructor
+    public SkipNotificationsTrait() {
+        //empty
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void decorateContext(SCMSourceContext<?, ?> context) {
+        if (context instanceof GitHubSCMSourceContext) {
+            GitHubSCMSourceContext ctx = (GitHubSCMSourceContext) context;
+            ctx.withNotificationsDisabled(true);
+        }
+    }
+
+    /**
+     * Our {@link hudson.model.Descriptor}
+     */
+    @Extension
+    @Symbol("skipGitHubNotifications")
+    public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return org.jenkinsci.plugins.github.notifications.Messages.SkipNotificationsTrait_displayName();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Class<? extends SCMSourceContext> getContextClass() {
+            return GitHubSCMSourceContext.class;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Class<? extends SCMSource> getSourceClass() {
+            return GitHubSCMSource.class;
+        }
+
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/github/notifications/SkipNotificationsTrait.java
+++ b/src/main/java/org/jenkinsci/plugins/github/notifications/SkipNotificationsTrait.java
@@ -1,7 +1,7 @@
 /*
 The MIT License
 
-Copyright (c) 2019, Elastic, Inc.
+Copyright (c) 2019, Elasticsearch B.V.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/org/jenkinsci/plugins/github/notifications/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/github/notifications/Messages.properties
@@ -1,0 +1,1 @@
+SkipNotificationsTrait.displayName=Skip build status notifications

--- a/src/main/resources/org/jenkinsci/plugins/github/notifications/SkipNotificationsTrait/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/github/notifications/SkipNotificationsTrait/config.jelly
@@ -1,0 +1,2 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core"  xmlns:f="/lib/form"/>

--- a/src/main/resources/org/jenkinsci/plugins/github/notifications/SkipNotificationsTrait/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/github/notifications/SkipNotificationsTrait/help.html
@@ -1,0 +1,3 @@
+<div>
+    Disables build status notifications.
+</div>


### PR DESCRIPTION
## Summary

Enable the GitHub Branch Source extension as the name of the plugin is independent of the branch source.

## Tasks
- Implement the skip trait for the GitHub notification
- Migrate to Documentation as Code [here](https://jenkins.io/blog/2019/10/21/plugin-docs-on-github/)
- Update some dependencies to solve the enforce rule.
